### PR TITLE
Minor updates to match current release of Debian,  Included usage of gdb-multiarch

### DIFF
--- a/README.org
+++ b/README.org
@@ -459,14 +459,20 @@ One of the big bonuses of using CMake is that it will hook into existing tools v
 ** GDB
 The first basic step is hookin' up a debugger.
 
-For some reason Debian (Testing) is missing a ~arm-none-eabi-gdb~, so I had to just download the whole GCC toolchain from [[https://developer.arm.com/open-source/gnu-toolchain/gnu-rm/downloads][ARM's website]] (this only works assuming you're running on a x64 machine). Just whatever you end up using, make sure you don't just run the system GDB! It won't throw you any errors and it will kinda work.. till it doesn't. 
+The host system will likely have have GDB installed for the host architecture (probably x64). Debain packages a gdb debugger that can handle many differet archectures called gdb-multiarch. A key feature of this version of gdb is that is will detect the archtecture to use based on the .elf file that you provided.
 
-Once we have the right version of *GDB* the next part becomes super easy b/c by default *OpenOCD* will provide us with a GDB server to which we can connect. We just need to disable the part where we flash the program and exit and replace it with a command to reset the chip and wait for GDB
+#+BEGIN_SRC 
+apt-get install gdb-multiarch
+#+END_SRC 
+
+make sure you don't run the system GDB! It won't throw you any errors and it will kinda work.. till it doesn't. 
+
+Once we have the multiarch version of *GDB* the next part becomes super easy b/c by default *OpenOCD* will provide us with a GDB server to which we can connect. We just need to disable the part where we flash the program and exit and replace it with a command to reset the chip and wait for GDB
 
 #+BEGIN_SRC c :tangle openocd_debug.cfg
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 transport select hla_swd
-source [find target/stm32f1x_stlink.cfg]
+source [find board/stm32f103c8_blue_pill.cfg
 reset_config srst_nogate
 #+END_SRC
 
@@ -493,7 +499,7 @@ Info : Target voltage: 2.913562
 Info : stm32f1x.cpu: hardware has 6 breakpoints, 4 watchpoints
 #+END_QUOTE
 
-We open another terminal and run our ~arm-none-eabi-gdb~ to bring up the GDB "shell" The next few steps will connect to the OpenOCD server, stop the program running on it, unlock the chip, and load our new program
+We open another terminal and run our ~gdb-multiarch blinky.elf~ to bring up the GDB "shell". The next few steps will connect to the OpenOCD server, stop the program running on it, unlock the chip, and load our new program
 
 #+BEGIN_SRC 
 > target remote localhost:3333
@@ -501,8 +507,6 @@ We open another terminal and run our ~arm-none-eabi-gdb~ to bring up the GDB "sh
 > monitor stm32f1x unlock 0
 > load blinky.elf
 #+END_SRC
-
-Now you can set breakpoint, run code, inspect the stack and variables, etc. etc. Look at the GDB manual for all the juicy details - and don't forget about the very handy [[https://ftp.gnu.org/old-gnu/Manuals/gdb-5.1.1/html_chapter/gdb_19.html][TUI Mode]]. Start it with ~C-x C-a~, then hit ~C-x 2~ to bring up the assembly. And type ~s~ or ~n~ to step one line of code at a time and ~si~ to step one assembly instruction at a time!
 
 ** KDevelop
 

--- a/README.org
+++ b/README.org
@@ -508,6 +508,7 @@ We open another terminal and run our ~gdb-multiarch blinky.elf~ to bring up the 
 > load blinky.elf
 #+END_SRC
 
+Now you can set breakpoint, run code, inspect the stack and variables, etc. etc. Look at the GDB manual for all the juicy details - and don't forget about the very handy [[https://ftp.gnu.org/old-gnu/Manuals/gdb-5.1.1/html_chapter/gdb_19.html][TUI Mode]]. Start it with ~C-x C-a~, then hit ~C-x 2~ to bring up the assembly and/or source code. Pressing ~C-x 2~ again will toggle between source, assembler, and registers.  Pressing  And type ~s~ or ~n~ to step one line of code at a time and ~si~ to step one assembly instruction at a time!
 ** KDevelop
 
 To demonstrate how flexible things get thanks to CMake, next I'll show you how to setup KDevelop to run everything for us. In principle this should work equally well with QtCreator or CLion or CQuery/Emacs. You can even hook up linters and other fancy Clang based tools now pretty easily. So this isn't an endorsement of KDevelop over the alternatives b/c after all it's sorta like Visual Studio - a big drop-box driven mess - but I'm just familiar with it and it's quick and easy to get up and running with a CMake project. We'll be able to jump around our code and refactor things in no time. The easiest way to get started is to just get the KDevelop AppImage from [[https://www.kdevelop.org/download][their website]]. Download it, make it executable with ~chmod +x $KDevelopAppImageFile~ and run!

--- a/openocd.cfg
+++ b/openocd.cfg
@@ -1,5 +1,5 @@
 
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 transport select hla_swd
-source [find target/stm32f1x_stlink.cfg]
+source [find board/stm32f103c8_blue_pill.cfg]
 program blinky.elf verify reset exit


### PR DESCRIPTION
These changes are to reflect the updated st-link and bluepill files as shipped with openodc version 0.12.0-1+rpt1 on Debian Bookworm. 

I also took the liberty of migrating to the use of gbd-multiarch as opposed to getting the version from the ARM website.   Invoking the gdb-multiarch in the manner in which I do also allows you to navigate the source listings as well as the assembly in the debugger sessions right there in the debugger.  (The key was invoking the debugger with the elf file as an argument)  

Thank you for the very good tutorial on getting the bluepill up and running and especially the explanation of using Cmake which was a leap that was always to large for me until now. 

I know this is six years old, however please note that the rest of the instructions worked flawlessly after all this time. 

Many Thanks,
David 



